### PR TITLE
Raise deployment target to 10.13 so it builds on current Xcode

### DIFF
--- a/AvroKeyboard.xcodeproj/project.pbxproj
+++ b/AvroKeyboard.xcodeproj/project.pbxproj
@@ -450,7 +450,7 @@
 				GCC_VERSION = com.apple.compilers.llvm.clang.1_0;
 				INFOPLIST_FILE = Info.plist;
 				INSTALL_PATH = "\"$(LOCAL_LIBRARY_DIR)/Input Methods/\"";
-				MACOSX_DEPLOYMENT_TARGET = 10.7;
+				MACOSX_DEPLOYMENT_TARGET = 10.13;
 				PRODUCT_BUNDLE_IDENTIFIER = com.omicronlab.inputmethod.AvroKeyboard;
 				PRODUCT_NAME = "Avro Keyboard";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -473,7 +473,7 @@
 				GCC_VERSION = com.apple.compilers.llvm.clang.1_0;
 				INFOPLIST_FILE = Info.plist;
 				INSTALL_PATH = "$(HOME)/Applications";
-				MACOSX_DEPLOYMENT_TARGET = 10.7;
+				MACOSX_DEPLOYMENT_TARGET = 10.13;
 				PRODUCT_BUNDLE_IDENTIFIER = com.omicronlab.inputmethod.AvroKeyboard;
 				PRODUCT_NAME = "Avro Keyboard";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -503,7 +503,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = NO;
-				MACOSX_DEPLOYMENT_TARGET = 10.7;
+				MACOSX_DEPLOYMENT_TARGET = 10.13;
 				ONLY_ACTIVE_ARCH = YES;
 			};
 			name = Debug;
@@ -529,7 +529,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = NO;
-				MACOSX_DEPLOYMENT_TARGET = 10.7;
+				MACOSX_DEPLOYMENT_TARGET = 10.13;
 			};
 			name = Release;
 		};


### PR DESCRIPTION
Thanks for iAvro. On current Xcode the project does not build out of the box:

```
error: The macOS deployment target 'MACOSX_DEPLOYMENT_TARGET' is set to 10.7,
but the range of supported deployment target versions is 10.13 to 26.x.
```

This raises `MACOSX_DEPLOYMENT_TARGET` from 10.7 to 10.13 (the lowest value
current Xcode accepts) in all four build configurations. No other changes.

## Verification

On macOS 26.5, Apple Silicon (MacBook Air M5), Xcode 26:

- `pod install`, then `xcodebuild -workspace "AvroKeyboard.xcworkspace" -scheme "Avro Keyboard" -configuration Release` succeeds.
- Produces a universal `arm64 + x86_64` binary (no Rosetta on Apple Silicon).
- Installed as a system input method and typed Bangla phonetically: composing,
  space commit, and arrow-key candidate selection (with the panel highlight
  moving) all work. The existing `moveDown:`/`moveUp:` candidate navigation
  still functions correctly on current macOS.

Note for anyone building this: RegexKitLite 4.0 is published over SVN, so
`pod install` needs `svn` available (`brew install subversion`). That is a
CocoaPods/pod-source detail, not changed here.
