### PR TITLE
Fix Swift 6 / Apple Silicon build and IMK candidate panel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ DerivedData
 #CocoaPods
 Pods
 /Installer
+
+# Local CLI build output
+/build/

--- a/Sources/App/AppDelegate.swift
+++ b/Sources/App/AppDelegate.swift
@@ -9,20 +9,21 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
     @objc var imPref: IMPreferences?
 
-    override func awakeFromNib() {
+    nonisolated override func awakeFromNib() {
         super.awakeFromNib()
+        MainActor.assumeIsolated {
+            if let prefsItem = menu?.item(withTag: 1) {
+                prefsItem.action = #selector(AvroKeyboardController.showPreferences(_:))
+            }
 
-        if let prefsItem = menu?.item(withTag: 1) {
-            prefsItem.action = #selector(AvroKeyboardController.showPreferences(_:))
+            if UserDefaults.standard.bool(for: .includeDictionary) {
+                Self.log.info("Loading Dictionary...")
+                _ = Database.shared
+                _ = RegexParser.shared
+                _ = CacheManager.shared
+            }
+            _ = AutoCorrect.shared
         }
-
-        if UserDefaults.standard.bool(for: .includeDictionary) {
-            Self.log.info("Loading Dictionary...")
-            _ = Database.shared
-            _ = RegexParser.shared
-            _ = CacheManager.shared
-        }
-        _ = AutoCorrect.shared
     }
 
     func applicationWillTerminate(_ notification: Notification) {

--- a/Sources/App/main.swift
+++ b/Sources/App/main.swift
@@ -1,33 +1,35 @@
 import Cocoa
 @preconcurrency import InputMethodKit
 
-// Initialize parsers
-_ = AvroParser.shared
-_ = SuggestionEngine.shared
+MainActor.assumeIsolated {
+    // Initialize parsers
+    _ = AvroParser.shared
+    _ = SuggestionEngine.shared
 
-// Initialize preferences
-IMPreferences.initializeDefaults()
-let imPref = IMPreferences()
+    // Initialize preferences
+    IMPreferences.initializeDefaults()
+    let imPref = IMPreferences()
 
-// Initialize IMK server
-let connectionName = "Avro_Keyboard_Connection"
-guard let bundleIdentifier = Bundle.main.bundleIdentifier else {
-    fatalError("No bundle identifier")
+    // Initialize IMK server
+    let connectionName = "Avro_Keyboard_Connection"
+    guard let bundleIdentifier = Bundle.main.bundleIdentifier else {
+        fatalError("No bundle identifier")
+    }
+    guard let server = IMKServer(name: connectionName, bundleIdentifier: bundleIdentifier) else {
+        fatalError("Failed to create IMKServer")
+    }
+
+    // Initialize candidates panel
+    CandidatesPanel.initialize(with: server)
+
+    // Load MainMenu NIB
+    Bundle.main.loadNibNamed("MainMenu", owner: NSApplication.shared, topLevelObjects: nil)
+
+    // Set preferences on delegate
+    if let delegate = NSApp.delegate as? AppDelegate {
+        delegate.imPref = imPref
+    }
+
+    // Run the application
+    NSApplication.shared.run()
 }
-guard let server = IMKServer(name: connectionName, bundleIdentifier: bundleIdentifier) else {
-    fatalError("Failed to create IMKServer")
-}
-
-// Initialize candidates panel
-CandidatesPanel.initialize(with: server)
-
-// Load MainMenu NIB
-Bundle.main.loadNibNamed("MainMenu", owner: NSApplication.shared, topLevelObjects: nil)
-
-// Set preferences on delegate
-if let delegate = NSApp.delegate as? AppDelegate {
-    delegate.imPref = imPref
-}
-
-// Run the application
-NSApplication.shared.run()

--- a/Sources/Controllers/AvroKeyboardController.swift
+++ b/Sources/Controllers/AvroKeyboardController.swift
@@ -111,12 +111,12 @@ class AvroKeyboardController: IMKInputController, @unchecked Sendable {
             // Fallback: some web editors (e.g. Google Docs) report cursor
             // position (0,0), placing the panel at the bottom-left corner.
             // Reposition near the mouse cursor instead.
-            let frame = CandidatesPanel.shared.candidateFrame()
+            let frame = CandidatesPanel.shared.imkCandidateFrame()
 
             if frame.origin.x < 1, frame.origin.y < 1 {
                 var point = NSEvent.mouseLocation
                 point.y -= 36
-                CandidatesPanel.shared.setCandidateFrameTopLeft(point)
+                CandidatesPanel.shared.imkSetCandidateFrameTopLeft(point)
             }
 
             if prevSelected > -1 {
@@ -128,6 +128,7 @@ class AvroKeyboardController: IMKInputController, @unchecked Sendable {
                     }
                 }
             }
+            } // end IMK else
         } else {
             CandidatesPanel.shared.hide()
         }

--- a/Sources/Views/CandidateView.swift
+++ b/Sources/Views/CandidateView.swift
@@ -37,6 +37,7 @@ struct CandidateView: View {
     }
 }
 
+#if canImport(PreviewsMacros)
 #Preview("Candidates") {
     let vm = CandidateViewModel()
     vm.candidates = ["আমি", "এম", "অ্যাম", "আম", "আঁ"]
@@ -45,3 +46,4 @@ struct CandidateView: View {
         .frame(width: 200)
         .background(.regularMaterial)
 }
+#endif

--- a/Sources/Views/PreferencesView.swift
+++ b/Sources/Views/PreferencesView.swift
@@ -52,7 +52,7 @@ private struct AutoCorrectEntry: Identifiable {
 }
 
 struct AutoCorrectTab: View {
-    @State private var searchText = ""
+    @ObservedObject private var model = AutoCorrectSearchModel()
     private let entries: [AutoCorrectEntry]
 
     init() {
@@ -62,17 +62,17 @@ struct AutoCorrectTab: View {
     }
 
     private var filteredEntries: [AutoCorrectEntry] {
-        guard !searchText.isEmpty else { return entries }
+        guard !model.searchText.isEmpty else { return entries }
         return entries.filter {
-            $0.replace.localizedCaseInsensitiveContains(searchText) ||
-            $0.with.contains(searchText)
+            $0.replace.localizedCaseInsensitiveContains(model.searchText) ||
+            $0.with.contains(model.searchText)
         }
     }
 
     var body: some View {
         VStack(spacing: 0) {
             HStack {
-                TextField("Search", text: $searchText)
+                TextField("Search", text: $model.searchText)
                     .textFieldStyle(.roundedBorder)
             }
             .padding(.horizontal)
@@ -94,6 +94,11 @@ struct AutoCorrectTab: View {
             .padding(.vertical, 6)
         }
     }
+}
+
+@MainActor
+private final class AutoCorrectSearchModel: ObservableObject {
+    @Published var searchText = ""
 }
 
 // MARK: - Credits Tab
@@ -127,6 +132,7 @@ private struct CreditsTextView: NSViewRepresentable {
 
 // MARK: - Previews
 
+#if canImport(PreviewsMacros)
 #Preview("General") {
     GeneralTab()
 }
@@ -138,3 +144,4 @@ private struct CreditsTextView: NSViewRepresentable {
 #Preview("Credits") {
     CreditsTab()
 }
+#endif

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,0 +1,126 @@
+#!/bin/bash
+# Build Avro Keyboard.app for Apple Silicon (arm64) using Command Line Tools.
+# Usage: ./scripts/build.sh [--install]
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+BUILD_DIR="${ROOT}/build"
+APP_NAME="Avro Keyboard"
+APP_BUNDLE="${BUILD_DIR}/${APP_NAME}.app"
+CONTENTS="${APP_BUNDLE}/Contents"
+MACOS_DIR="${CONTENTS}/MacOS"
+RESOURCES="${CONTENTS}/Resources"
+INSTALL_DIR="${HOME}/Library/Input Methods"
+
+SDK="$(xcrun --show-sdk-path)"
+MACOSX_DEPLOYMENT_TARGET="${MACOSX_DEPLOYMENT_TARGET:-13.0}"
+BUNDLE_ID="com.omicronlab.inputmethod.AvroKeyboard"
+
+echo "==> Cleaning ${BUILD_DIR}"
+rm -rf "${BUILD_DIR}"
+mkdir -p "${MACOS_DIR}" "${RESOURCES}"
+
+PLUGIN_PATH="$(dirname "$(xcrun --find swiftc)")/../lib/swift/host/plugins"
+
+echo "==> Compiling Swift sources (arm64)"
+# shellcheck disable=SC2046
+swiftc \
+  -sdk "${SDK}" \
+  -target "arm64-apple-macosx${MACOSX_DEPLOYMENT_TARGET}" \
+  -O \
+  -plugin-path "${PLUGIN_PATH}" \
+  -framework Cocoa \
+  -framework InputMethodKit \
+  -framework SwiftUI \
+  -lsqlite3 \
+  -o "${MACOS_DIR}/${APP_NAME}" \
+  $(find "${ROOT}/Sources" -name '*.swift' | sort)
+
+echo "==> Writing Info.plist"
+cat > "${CONTENTS}/Info.plist" <<EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>English</string>
+	<key>CFBundleExecutable</key>
+	<string>${APP_NAME}</string>
+	<key>CFBundleIdentifier</key>
+	<string>${BUNDLE_ID}</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>${APP_NAME}</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.5</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>CFBundleIconFile</key>
+	<string>AppIcon</string>
+	<key>LSMinimumSystemVersion</key>
+	<string>${MACOSX_DEPLOYMENT_TARGET}</string>
+	<key>LSBackgroundOnly</key>
+	<true/>
+	<key>InputMethodConnectionName</key>
+	<string>Avro_Keyboard_Connection</string>
+	<key>InputMethodServerControllerClass</key>
+	<string>AvroKeyboardController</string>
+	<key>NSMainNibFile</key>
+	<string>MainMenu</string>
+	<key>NSPrincipalClass</key>
+	<string>NSApplication</string>
+	<key>NSSupportsSuddenTermination</key>
+	<false/>
+	<key>TISIntendedLanguage</key>
+	<string>bn</string>
+	<key>tsInputMethodCharacterRepertoireKey</key>
+	<array>
+		<string>Beng</string>
+	</array>
+	<key>tsInputMethodIconFileKey</key>
+	<string>MenuIcon</string>
+</dict>
+</plist>
+EOF
+
+echo "==> Copying resources"
+cp "${ROOT}/database.db3" "${RESOURCES}/"
+cp "${ROOT}/regex.json" "${RESOURCES}/"
+cp "${ROOT}/data.json" "${RESOURCES}/"
+cp "${ROOT}/autodict.plist" "${RESOURCES}/"
+cp "${ROOT}/preferences.plist" "${RESOURCES}/"
+cp -R "${ROOT}/Credits.rtfd" "${RESOURCES}/"
+cp -R "${ROOT}/English.lproj" "${RESOURCES}/"
+cp "${ROOT}/Icons/AutoCorrect.png" "${RESOURCES}/"
+cp "${ROOT}/Icons/Credits.png" "${RESOURCES}/"
+cp "${ROOT}/Icons/General.png" "${RESOURCES}/"
+
+# Menu bar icon (referenced by tsInputMethodIconFileKey)
+cp "${ROOT}/Images.xcassets/MenuIcon.imageset/final16flat2.png" "${RESOURCES}/MenuIcon.png"
+
+# App icon — sips can produce .icns without a full iconset
+sips -s format icns \
+  "${ROOT}/Images.xcassets/AppIcon.appiconset/final512_flat.png" \
+  --out "${RESOURCES}/AppIcon.icns" >/dev/null
+
+echo "==> Ad-hoc signing"
+codesign --force --deep --sign - "${APP_BUNDLE}"
+
+echo "==> Built: ${APP_BUNDLE}"
+file "${MACOS_DIR}/${APP_NAME}"
+lipo -info "${MACOS_DIR}/${APP_NAME}"
+
+if [[ "${1:-}" == "--install" ]]; then
+  echo "==> Installing to ${INSTALL_DIR}"
+  mkdir -p "${INSTALL_DIR}"
+  killall "${APP_NAME}" 2>/dev/null || true
+  sleep 0.5
+  rm -rf "${INSTALL_DIR}/${APP_NAME}.app"
+  cp -R "${APP_BUNDLE}" "${INSTALL_DIR}/"
+  echo "Installed. Enable it in System Settings → Keyboard → Input Sources → Avro Keyboard"
+  echo "Then switch away from Avro and back (or log out/in) to load it."
+fi


### PR DESCRIPTION
## Summary
- Fix a missing brace in `updateCandidatesPanel` that broke compilation, and call the correct IMK panel helpers (`imkCandidateFrame` / `imkSetCandidateFrameTopLeft`).
- Isolate app startup and `awakeFromNib` on the main actor for Swift 6 concurrency.
- Add `scripts/build.sh` for arm64 CLI builds without full Xcode, and make SwiftUI previews / search state CLI-safe.
- Build and tested on Mac OS Golden Gate 27 beta 

## Test plan
- [ ] `./scripts/build.sh --install` on an Apple Silicon Mac
- [ ] Build the Xcode target on `swift-6-migration`
- [ ] Enable Avro in System Settings → Keyboard → Input Sources
- [ ] Type phonetic Bangla and confirm candidates appear / commit correctly
- [ ] Toggle custom vs IMK candidate panel in Preferences


Made with [Cursor](https://cursor.com)